### PR TITLE
Log total tokens.

### DIFF
--- a/summ_net.py
+++ b/summ_net.py
@@ -78,6 +78,7 @@ class SummNet(pl.LightningModule):
         self.save_hyperparameters()
         self.dim = dim
         self.max_length = max_length
+        self.total_train_tokens = 0
         self.save_hyperparameters()
         # Embed(B, T) -> (B, C, T)
         self.token_embedding_table = nn.Embedding(vocab_size, dim)
@@ -139,6 +140,8 @@ class SummNet(pl.LightningModule):
         return torch.optim.AdamW(self.parameters(), lr=1e-5, weight_decay=1e-2)
 
     def training_step(self, batch, batch_idx):
+        self.total_train_tokens += torch.sum(batch['num_tokens'])
+        self.log('train_tokens', self.total_train_tokens)
         return self._shared_eval(batch['input_ids'], batch_idx, 'train')
     
     def validation_step(self, batch, batch_idx):

--- a/train.py
+++ b/train.py
@@ -83,10 +83,10 @@ def main(argv):
                          limit_val_batches=337,
                          limit_test_batches=8000,
                          max_epochs=args.max_epochs,
-                         #logger=pl.loggers.WandbLogger(
-                         #    name="microlm",
-                         #    log_model=True,
-                         #   ),
+                         logger=pl.loggers.WandbLogger(
+                             name="microlm",
+                             log_model=True,
+                            ),
                          )
 
     stream_factory = text_data.StreamingTextDataModule if args.streaming else text_data.BasicDataModule


### PR DESCRIPTION
Keep track of how many tokens we've trained on, for smoother and more directly comparable plots across runs. Since the batches contain variable length training segments, it doesn't always make sense to compare in training steps.